### PR TITLE
Gameplay: Add game functionality for move confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@
 - safari seems to log an error with PN sometimes. more investigating could be good.
   - looks to be on unsubscribeAll()?
 
+- previously moved card isn't maintained when page is reloaded. allows for cheating by moving, reloading, moving same card.
+- loading old games sometimes gives wrong board states. maybe an issue with flipped? maybe history?
+
+## decisions that need to be made:
+
+1. victory/defeat screen
+2. back button
+3. move potential (transparent overlay?)
+4. possible move notifier on stacked tiles
+
 ## next steps
 
 1. ~play online~

--- a/app/assets/stylesheets/board.scss
+++ b/app/assets/stylesheets/board.scss
@@ -60,6 +60,12 @@
 .board__cell {
   position: relative;
   flex-basis: 33%;
+
+  // for hovering card. other cards are in a position absolute contianer so they ignore flex
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   &::before {
     @include beforeSquare;
   }
@@ -84,6 +90,12 @@
   }
   &--hidden {
     display: none;
+  }
+  &--hovering {
+    opacity: 0.75;
+    height: 20vh;
+    position: static;
+    z-index: 10;
   }
 }
 

--- a/app/javascript/packs/Components/Card.jsx
+++ b/app/javascript/packs/Components/Card.jsx
@@ -13,7 +13,7 @@ class Card extends Component {
       if(this.props.active){
         this.props.cancelMove();
       }else{
-        this.props.highlightMoves();
+        this.props.highlightMoves && this.props.highlightMoves();
       }
     }
   }

--- a/app/javascript/packs/Components/Cell.jsx
+++ b/app/javascript/packs/Components/Cell.jsx
@@ -11,9 +11,7 @@ class Cell extends Component {
   highlightClick () {
     this.props.showStack();
     if(this.props.confirmMove) {
-      if (window.confirm('Move to the highlighted square?')) {
-        this.props.moveCard();
-      }
+        this.props.setPreppedMove(this.props.moveCard);
     } else {
       this.props.moveCard();
     }
@@ -49,7 +47,7 @@ class Cell extends Component {
               value={card.value}
               url={this.props.getCardUrl(card.deck, card.value, card.faceDown)}
               faceDown={card.faceDown}
-              highlightMoves={this.props.highlightMoves}
+              highlightMoves={!(this.props.confirmMove && this.props.highlighted) && this.props.highlightMoves}
               cancelMove={this.props.cancelMove}
               active={card.active}
               isSmuggled={card.isSmuggled}
@@ -57,6 +55,13 @@ class Cell extends Component {
               stackClass={`card--${position}-of-${isOverflowing ? 4 : numCards}`}
             /></div>
         })}
+        {this.props.hoverCard && ((card) => <Card
+            deck={card.deck}
+            value={card.value}
+            url={this.props.getCardUrl(card.deck, card.value)}
+            faceDown={false}
+            class={'card--hovering'}
+          />)(this.props.hoverCard)}
       </div>
     );
   }

--- a/app/javascript/packs/Components/MoveConfirmation.jsx
+++ b/app/javascript/packs/Components/MoveConfirmation.jsx
@@ -17,10 +17,16 @@ class MoveConfirmation extends Component {
 
   renderMoveConfirmation () {
     return (<div className="move-confirmation__button-container">
-              <button className="move-confirmation__button move-confirmation__button--cancel">
+              <button
+                onClick={this.props.cancelMove}
+                className="move-confirmation__button move-confirmation__button--cancel"
+              >
                 <img className="move-confirmation__button-image" src={this.props.assets.xIcon} alt="Cancel Move"/>
               </button>
-              <button className="move-confirmation__button move-confirmation__button--confirm">
+              <button
+                onClick={this.props.makeMove}
+                className="move-confirmation__button move-confirmation__button--confirm"
+              >
                 <img className="move-confirmation__button-image" src={this.props.assets.checkIcon} alt="Confirm Move"/>
               </button>
             </div>)


### PR DESCRIPTION
- Remove stateless functions from binding in Game constructor
- Create state and function for setting preppedMove object
  - Prepped move has the original location the card was moving from, the card itself, a bound function to complete the move
- Add cancel and confirm move functionality to the buttons in the confirm move state screen
- Note bugs and pressing decisions in README
- Conditionally call highlightMoves from cards to make hovering over your own card not change the active card
- Add basic styles (first pass) for hovering cards