### PR TITLE
Fix stack height bug in safari

### DIFF
--- a/app/assets/stylesheets/stackPreview.scss
+++ b/app/assets/stylesheets/stackPreview.scss
@@ -23,7 +23,6 @@
   }
 
   &__card {
-    max-height: 80%;
     margin: 0.25rem;
   }
 
@@ -32,6 +31,7 @@
     overflow: auto;
     flex-grow: 1;
     flex-shrink: 1;
+    height: 100%;
   }
   // &__slider {
   //   -webkit-appearance: none;


### PR DESCRIPTION
For an element to have percentage height in safari its parent needs to have an explicitly stated height via the height attribute. letting flexbox handle the height of the element means safari uses the default height of the element instead of the listed percentage. this normally shouldn't be a problem as you can use flex to set its height, but i wanted auto height with the images so it broke hard.