### PR TITLE
Play page profile pictures distortion

### DIFF
--- a/app/assets/stylesheets/playerIcons.scss
+++ b/app/assets/stylesheets/playerIcons.scss
@@ -10,7 +10,7 @@
   flex-direction: column;
 
   &__player-container {
-    height: 45%;
+    height: 40%;
     transition: height 0.5s;
     display: flex;
     flex-direction: column;
@@ -29,11 +29,13 @@
       background-color: $countryPlayerColor;
     }
     &--active {
-      height: 55%;
+      height: 60%;
     }
   }
 
   &__profile-picture {
+    transition: height 0.5s, width 0.5s;
+    display: flex;
     max-width: 100%;
     width: auto;
     height: 100%;
@@ -72,12 +74,15 @@
   }
   &__turn-data {
     @include descriptive-text(true);
+    @include textOutline(black);
     text-align: center;
     width: 100%;
     margin: 0;
     max-height: 7.5rem;
     transition: max-height 0.5s;
     overflow: hidden;
+    box-sizing: border-box;
+    padding: 0 0.5rem;
     &--hidden {
       max-height: 0;
     }
@@ -92,12 +97,14 @@
   &__move-container {
     width: 100%;
     height: 3rem;
-    padding: 0.5rem 0 0.5rem 2rem;
+    padding: 0.5rem 0.25rem;
     box-sizing: border-box;
+    text-align: center;
   }
   &__move-data {
     @include descriptive-text(false);
     margin: 0;
+    @include textOutline(black);
   }
 
   &__move-bubble {
@@ -106,7 +113,8 @@
     height: 1.75rem;
     width: 1.75rem;
     display: inline-block;
-    margin: 0 0.75rem;
+    margin-left: 0.75rem;
+    @include boxShadowOutline(black);
   }
 
   &__winner-banner {

--- a/app/assets/stylesheets/playerIcons.scss
+++ b/app/assets/stylesheets/playerIcons.scss
@@ -115,6 +115,11 @@
     display: inline-block;
     margin-left: 0.75rem;
     @include boxShadowOutline(black);
+
+    &--hidden {
+      opacity: 0;
+      box-shadow: none;
+    }
   }
 
   &__winner-banner {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -87,6 +87,18 @@ $font-myriad: myriad_pro_regular;
     0 -2px $color
   ;
 }
+@mixin boxShadowOutline ($color) {
+  box-shadow:
+    2px 2px $color,
+    -2px 2px $color,
+    2px -2px $color,
+    -2px -2px $color,
+    0 2px $color,
+    -2px 0 $color,
+    2px 0 $color,
+    0 -2px $color
+  ;
+}
 @mixin outlineShadow ($color1, $color2) {
   text-shadow:
     2px 2px $color1,

--- a/app/javascript/packs/Components/PlayerIcons.jsx
+++ b/app/javascript/packs/Components/PlayerIcons.jsx
@@ -86,13 +86,13 @@ class PlayerIcons extends Component {
   }
 
   generateMovesCircles() {
-    return new Array(this.props.movesLeft)
-      .fill('')
-      .map((_, i)=> {
+    return [1, 2]
+      .map((num)=> {
+          const classes = `player-icons__move-bubble${num > this.props.movesLeft ? ' player-icons__move-bubble--hidden' : ''}`
         return (
           <span
-            key={`bubble-${i}`}
-            className="player-icons__move-bubble"
+            key={`bubble-${num}`}
+            className={classes}
           ></span>
         );
       });

--- a/app/javascript/packs/Components/PlayerIcons.jsx
+++ b/app/javascript/packs/Components/PlayerIcons.jsx
@@ -1,24 +1,68 @@
 import React, { Component } from 'react';
 
+const MOVE_CONTAINER_HEIGHT = 3;
+const TURN_MARGIN_HEIGHT = 1;
+const PICTURE_CONTAINER_MARGIN_HEIGHT = 3;
+const STATIC_ITEMS_HEIGHT = MOVE_CONTAINER_HEIGHT + TURN_MARGIN_HEIGHT + PICTURE_CONTAINER_MARGIN_HEIGHT;
+const WRAPPING_WIDTHS_IN_PX = {
+  country: [1337, 787],
+  city: [1076, 749]
+};
+const LINE_HEIGHT = 2.5;
+
+const getActivePlayerTextHeight = (screenWidth, deck) => {
+  const numberOfLines = WRAPPING_WIDTHS_IN_PX[deck].reduce(
+    (wraps, size) => size < screenWidth ? wraps + 1 : wraps,
+    1
+  );
+  return numberOfLines * LINE_HEIGHT;
+};
+
+const getImageHeight = (deck, isActive) => {
+  const userPane = ((isActive ? 0.6 : 0.4) * document.body.offsetHeight) / 16;
+  const playerTextHeight = isActive ? getActivePlayerTextHeight(document.body.offsetWidth, deck) : 0;
+  return userPane - STATIC_ITEMS_HEIGHT - playerTextHeight;
+};
+
+const getImageSize = (containerWidth, deck, isActive) => {
+  const usableWidth = (containerWidth / 16) - 1;
+  return Math.min(usableWidth, getImageHeight(deck, isActive));
+}
+
+const getAllImageSizes = containerWidth => ({
+  city: {
+    active: getImageSize(containerWidth, 'city', true),
+    notActive: getImageSize(containerWidth, 'city', false),
+  },
+  country: {
+    active: getImageSize(containerWidth, 'country', true),
+    notActive: getImageSize(containerWidth, 'country', false),
+  }
+});
+
 class PlayerIcons extends Component {
   constructor(props){
     super(props);
-    this.state = {
-      mapping: {
-        country: this.props.flipped ? 'top' : 'bottom',
-        city: this.props.flipped ? 'bottom' : 'top',
-        top: this.props.flipped ? 'country' : 'city',
-        bottom: this.props.flipped ? 'city' : 'country',
-      }
+    this.mapping = {
+      country: this.props.flipped ? 'top' : 'bottom',
+      city: this.props.flipped ? 'bottom' : 'top',
+      top: this.props.flipped ? 'country' : 'city',
+      bottom: this.props.flipped ? 'city' : 'country',
     }
+    const defaultContainerWidth = document.body.offsetWidth * 0.3;
+    this.state = {
+      imageSizes: getAllImageSizes(defaultContainerWidth)
+    };
   }
 
   getPlayerData(position, key) {
-    return this.props.playersData[this.state.mapping[position]][key]
+    return this.props.playersData[this.mapping[position]][key]
   }
 
-  generateUserPicture(position){
-    const deck = this.state.mapping[position];
+  generateUserPicture(position, isActive){
+    const deck = this.mapping[position];
+    const imageSize = `${this.state.imageSizes[deck][isActive ? 'active' : 'notActive']}rem`;
+    const imageStyle = {height: imageSize, width: imageSize};
     return (
       <div className="player-icons__user-picture-container">
         {this.props.winner && this.props.winner === deck &&
@@ -29,9 +73,10 @@ class PlayerIcons extends Component {
           />
         }
         <img
-          alt={`user ${this.getPlayerData(position, 'username')}'s' profile picture`}
+          alt={`${this.getPlayerData(position, 'username')}'s profile picture`}
           src={this.getPlayerData(position, 'url')}
           className="player-icons__profile-picture"
+          style={imageStyle}
         />
         <p className={`player-icons__user-name player-icons__user-name--${deck}`}>
           {this.getPlayerData(position, 'username')}
@@ -64,7 +109,7 @@ class PlayerIcons extends Component {
       <p
         {...attrs}
       >
-        {`${this.state.mapping[position]} Bears' Turn`}
+        {`${this.mapping[position]} Bears' Turn`}
       </p>
     );
   }
@@ -80,13 +125,13 @@ class PlayerIcons extends Component {
         'player-icons__player-container--bottom',
       ],
     };
-    const activePosition = this.state.mapping[this.props.active];
-    classes[this.state.mapping.country].push('player-icons__player-container--country');
-    classes[this.state.mapping.city].push('player-icons__player-container--city');
+    const activePosition = this.mapping[this.props.active];
+    classes[this.mapping.country].push('player-icons__player-container--country');
+    classes[this.mapping.city].push('player-icons__player-container--city');
     classes[activePosition].push('player-icons__player-container--active');
 
     return (
-      <div className="player-icons">
+      <section className="player-icons" aria-label="Player information">
         <div className={classes.top.join(' ')}>
           <div className='player-icons__move-container'>
             {activePosition === 'top' &&
@@ -95,12 +140,12 @@ class PlayerIcons extends Component {
               </p>
             }
           </div>
-          {this.generateUserPicture('top')}
+          {this.generateUserPicture('top', activePosition === 'top')}
           {this.generateTurnData(activePosition, 'top')}
         </div>
         <div className={classes.bottom.join(' ')}>
           {this.generateTurnData(activePosition, 'bottom')}
-          {this.generateUserPicture('bottom')}
+          {this.generateUserPicture('bottom', activePosition !== 'top')}
           <div className='player-icons__move-container'>
             {activePosition === 'bottom' &&
               <p className="player-icons__move-data" aria-label={`Moves left: ${this.props.movesLeft}`}>
@@ -109,7 +154,7 @@ class PlayerIcons extends Component {
             }
           </div>
         </div>
-      </div>
+      </section>
     );
   };
 }


### PR DESCRIPTION
Profile pictures on the play game page were definitely not circles on smaller sized screens and would consistently break on some browsers (Safari). This sets the height and width with javascript to ensure correct sizes and circular shape. Since it is being hard coded now it also implements a throttled resize listener to handle page size changes.
It also makes some small accessibility and visual improvements