### PR TITLE
Error routing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
       redirect_to @user
     else
       @errors = @user.errors.full_messages
-      render 'new'
+      render 'new', layout: 'sessions'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,8 +16,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    redirect_to '/sessions/new' unless current_user && current_user.id == params[:id].to_i
-    render layout: 'profile'
+    if current_user && current_user.id == params[:id].to_i
+      render layout: 'profile'
+    else
+      redirect_to '/sessions/new'
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,10 @@ Rails.application.routes.draw do
   mount ActionCable.server => '/cable'
 
   resource :sessions, only: [:new, :create, :destroy]
+  get 'sessions', to: 'sessions#new'
 
   resources :users, only: [:new, :create, :show]
+  get 'users', to: 'users#new'
 
   resources :games, only: [:new, :create, :show]
   get 'games/:id/play', to: 'games#play'


### PR DESCRIPTION
Several routes on reload or on visiting would throw an error.
This pr fixes:
- Reloading on failed form submission (users/new and sessions/new)
- Visiting a different user's profile (previously had a render and a redirect_to not separated by control flow)